### PR TITLE
Interpret weighted prompts

### DIFF
--- a/ldm/util.py
+++ b/ldm/util.py
@@ -201,3 +201,48 @@ def parallel_data_prefetch(
         return out
     else:
         return gather_res
+    
+def split_weighted_subprompts(text):
+    """
+    grabs all text up to the first occurrence of ':' 
+    uses the grabbed text as a sub-prompt, and takes the value following ':' as weight
+    if ':' has no value defined, defaults to 1.0
+    repeats until no text remaining
+    """
+    remaining = len(text)
+    prompts = []
+    weights = []
+    while remaining > 0:
+        if ":" in text:
+            idx = text.index(":") # first occurrence from start
+            # grab up to index as sub-prompt
+            prompt = text[:idx]
+            remaining -= idx
+            # remove from main text
+            text = text[idx+1:]
+            # find value for weight 
+            if " " in text:
+                idx = text.index(" ") # first occurence
+            else: # no space, read to end
+                idx = len(text)
+            if idx != 0:
+                try:
+                    weight = float(text[:idx])
+                except: # couldn't treat as float
+                    print(f"Warning: '{text[:idx]}' is not a value, are you missing a space?")
+                    weight = 1.0
+            else: # no value found
+                weight = 1.0
+            # remove from main text
+            remaining -= idx
+            text = text[idx+1:]
+            # append the sub-prompt and its weight
+            prompts.append(prompt)
+            weights.append(weight)
+        else: # no : found
+            if len(text) > 0: # there is still text though
+                # take remainder as weight 1
+                prompts.append(text)
+                weights.append(1.0)
+            remaining = 0
+    return prompts, weights


### PR DESCRIPTION
This pull request ports the weighted subprompts syntax mentioned at https://github.com/rinongal/textual_inversion/issues/35#issuecomment-1231190762 from [sd-webui/stable-diffusion-webui](https://github.com/sd-webui/stable-diffusion-webui).

> _grabs all text up to the first occurrence of `:` uses the grabbed text as a sub-prompt, and takes the value following `:` as weight if `:` has no value defined, defaults to 1.0 repeats until no text remaining_

### Source
* https://github.com/yue-here/sd-walker/blob/053437abff5fba92ce8c6f0383268d553448ad7e/txt2img_generator.py#L155-L166
* https://github.com/sd-webui/stable-diffusion-webui/blob/010b27ce9af3ee22758a0cf2650383525cb44a7b/optimizedSD/optimUtils.py#L5-L48

> **Warning**
> Admittedly, `ldm.util` is not the best place to paste that function; feel free to suggest a better place.