### PR TITLE
refactor(load_model_from_config): remove `model.cuda()` call

### DIFF
--- a/main.py
+++ b/main.py
@@ -35,7 +35,6 @@ def load_model_from_config(config, ckpt, verbose=False):
         print("unexpected keys:")
         print(u)
 
-    model.cuda()
     return model
 
 def get_parser(**parser_kwargs):


### PR DESCRIPTION
Signed-off-by: Ryan Russell <git@ryanrussell.org>

##### More background
This addresses issue #94 


##### Description
This removes the `model.cuda()` call from `load_model_from_config`.

Lightning will handle moving the model to the correct GPU, the original version would load the model in GPU 0 on multi-gpu machines, creating OOM issues.

##### Notes
```bash
$ grep -r 'model.cuda()'
main.py:    model.cuda() # This one removed, others left
scripts/evaluate_model.py:    model.cuda()
scripts/txt2img.py:    model.cuda()
scripts/sample_diffusion.py:    model.cuda()
scripts/stable_txt2img.py:    model.cuda()
```

There are other references, but this one was responsible for 6-8GB of VRAM on GPU 0. It is still possible to eliminate another 1-2GB of VRAM by updating these other references if someone wants to take this further.

##### Results
This enables users to utilize a  2x12GB VRAM GPU configuration both in parallel and in separate processes.