### PR TITLE
PyTroch-Lightning Version Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Do not track log outputs if they appear here.
+logs/**
+
+# Let's not track GBs of binary data.
+*.ckpt
+
+# Do not track Python compilation artifacts.
+**/__pycache__/**
+
+# Do not track local installation artifacts.
+latent_diffusion.egg-info/**

--- a/README.md
+++ b/README.md
@@ -61,18 +61,18 @@ python main.py --base configs/latent-diffusion/txt2img-1p4B-finetune.yaml
                -t 
                --actual_resume /path/to/pretrained/model.ckpt 
                -n <run_name> 
-               --gpus 0, 
+               --accelerator gpu 
                --data_root /path/to/directory/with/images
                --init_word <initialization_word>
 ```
 
 where the initialization word should be a single-token rough description of the object (e.g., 'toy', 'painting', 'sculpture'). If the input is comprised of more than a single token, you will be prompted to replace it.
 
-Please note that `init_word` is *not* the placeholder string that will later represent the concept. It is only used as a beggining point for the optimization scheme.
+Please note that `init_word` is *not* the placeholder string that will later represent the concept. It is only used as a beginning point for the optimization scheme.
 
 In the paper, we use 5k training iterations. However, some concepts (particularly styles) can converge much faster.
 
-To run on multiple GPUs, provide a comma-delimited list of GPU indices to the --gpus argument (e.g., ``--gpus 0,3,7,8``)
+With the above arguments, this will run on all available GPUs.  You can provide a comma-delimited list of GPU indices to the --devices argument (e.g., ``--devices 0,`` or ``--devices 0,3,7,8``) to specify specific GPUs or a single integer (e.g., ``--devices 2``) to indicate how many GPUs to use and let Pytorch-Lightning decide which ones to allocate to the task.
 
 Embeddings and output images will be saved in the log directory.
 

--- a/environment.yaml
+++ b/environment.yaml
@@ -15,7 +15,7 @@ dependencies:
     - pudb==2019.2
     - imageio==2.14.1
     - imageio-ffmpeg==0.4.7
-    - pytorch-lightning==1.5.9
+    - pytorch-lightning==1.7.7
     - omegaconf==2.1.1
     - test-tube>=0.7.5
     - streamlit>=0.73.1

--- a/ldm/models/autoencoder.py
+++ b/ldm/models/autoencoder.py
@@ -151,14 +151,14 @@ class VQModel(pl.LightningModule):
                                             last_layer=self.get_last_layer(), split="train",
                                             predicted_indices=ind)
 
-            self.log_dict(log_dict_ae, prog_bar=False, logger=True, on_step=True, on_epoch=True)
+            self.log_dict(log_dict_ae, prog_bar=False, logger=True, on_step=True, on_epoch=True, sync_dist=True)
             return aeloss
 
         if optimizer_idx == 1:
             # discriminator
             discloss, log_dict_disc = self.loss(qloss, x, xrec, optimizer_idx, self.global_step,
                                             last_layer=self.get_last_layer(), split="train")
-            self.log_dict(log_dict_disc, prog_bar=False, logger=True, on_step=True, on_epoch=True)
+            self.log_dict(log_dict_disc, prog_bar=False, logger=True, on_step=True, on_epoch=True, sync_dist=True)
             return discloss
 
     def validation_step(self, batch, batch_idx):
@@ -356,7 +356,7 @@ class AutoencoderKL(pl.LightningModule):
             # train encoder+decoder+logvar
             aeloss, log_dict_ae = self.loss(inputs, reconstructions, posterior, optimizer_idx, self.global_step,
                                             last_layer=self.get_last_layer(), split="train")
-            self.log("aeloss", aeloss, prog_bar=True, logger=True, on_step=True, on_epoch=True)
+            self.log("aeloss", aeloss, prog_bar=True, logger=True, on_step=True, on_epoch=True, sync_dist=True)
             self.log_dict(log_dict_ae, prog_bar=False, logger=True, on_step=True, on_epoch=False)
             return aeloss
 
@@ -365,7 +365,7 @@ class AutoencoderKL(pl.LightningModule):
             discloss, log_dict_disc = self.loss(inputs, reconstructions, posterior, optimizer_idx, self.global_step,
                                                 last_layer=self.get_last_layer(), split="train")
 
-            self.log("discloss", discloss, prog_bar=True, logger=True, on_step=True, on_epoch=True)
+            self.log("discloss", discloss, prog_bar=True, logger=True, on_step=True, on_epoch=True, sync_dist=True)
             self.log_dict(log_dict_disc, prog_bar=False, logger=True, on_step=True, on_epoch=False)
             return discloss
 

--- a/ldm/models/diffusion/classifier.py
+++ b/ldm/models/diffusion/classifier.py
@@ -170,9 +170,9 @@ class NoisyLatentImageClassifier(pl.LightningModule):
             logits, targets, k=5, reduction="mean"
         )
 
-        self.log_dict(log, prog_bar=False, logger=True, on_step=self.training, on_epoch=True)
+        self.log_dict(log, prog_bar=False, logger=True, on_step=self.training, on_epoch=True, sync_dist=True)
         self.log('loss', log[f"{log_prefix}/loss"], prog_bar=True, logger=False)
-        self.log('global_step', self.global_step, logger=False, on_epoch=False, prog_bar=True)
+        self.log('global_step', torch.tensor(self.global_step, dtype=torch.float32), logger=False, on_epoch=False, prog_bar=True)
         lr = self.optimizers().param_groups[0]['lr']
         self.log('lr_abs', lr, on_step=True, logger=True, on_epoch=False, prog_bar=True)
 

--- a/ldm/models/diffusion/ddpm.py
+++ b/ldm/models/diffusion/ddpm.py
@@ -921,8 +921,8 @@ class LatentDiffusion(DDPM):
 
     def _rescale_annotations(self, bboxes, crop_coordinates):  # TODO: move to dataset
         def rescale_bbox(bbox):
-            x0 = clamp((bbox[0] - crop_coordinates[0]) / crop_coordinates[2])
-            y0 = clamp((bbox[1] - crop_coordinates[1]) / crop_coordinates[3])
+            x0 = torch.clamp((bbox[0] - crop_coordinates[0]) / crop_coordinates[2])
+            y0 = torch.clamp((bbox[1] - crop_coordinates[1]) / crop_coordinates[3])
             w = min(bbox[2] / crop_coordinates[2], 1 - x0)
             h = min(bbox[3] / crop_coordinates[3], 1 - y0)
             return x0, y0, w, h
@@ -1136,7 +1136,7 @@ class LatentDiffusion(DDPM):
                                        score_corrector=score_corrector, corrector_kwargs=corrector_kwargs)
         if return_codebook_ids:
             raise DeprecationWarning("Support dropped.")
-            model_mean, _, model_log_variance, logits = outputs
+            # model_mean, _, model_log_variance, logits = outputs
         elif return_x0:
             model_mean, _, model_log_variance, x0 = outputs
         else:
@@ -1148,8 +1148,8 @@ class LatentDiffusion(DDPM):
         # no noise when t == 0
         nonzero_mask = (1 - (t == 0).float()).reshape(b, *((1,) * (len(x.shape) - 1)))
 
-        if return_codebook_ids:
-            return model_mean + nonzero_mask * (0.5 * model_log_variance).exp() * noise, logits.argmax(dim=1)
+        # if return_codebook_ids:
+        #     return model_mean + nonzero_mask * (0.5 * model_log_variance).exp() * noise, logits.argmax(dim=1)
         if return_x0:
             return model_mean + nonzero_mask * (0.5 * model_log_variance).exp() * noise, x0
         else:

--- a/ldm/models/diffusion/ddpm.py
+++ b/ldm/models/diffusion/ddpm.py
@@ -351,11 +351,11 @@ class DDPM(pl.LightningModule):
     def training_step(self, batch, batch_idx):
         loss, loss_dict = self.shared_step(batch)
 
-        self.log_dict(loss_dict, prog_bar=True,
-                      logger=True, on_step=True, on_epoch=True)
-
-        self.log("global_step", self.global_step,
+        self.log("global_step", torch.tensor(self.global_step, dtype=torch.float32),
                  prog_bar=True, logger=True, on_step=True, on_epoch=False)
+
+        self.log_dict(loss_dict, prog_bar=True,
+                      logger=True, on_step=True, on_epoch=True, sync_dist=True)
 
         if self.use_scheduler:
             lr = self.optimizers().param_groups[0]['lr']
@@ -369,8 +369,8 @@ class DDPM(pl.LightningModule):
         with self.ema_scope():
             _, loss_dict_ema = self.shared_step(batch)
             loss_dict_ema = {key + '_ema': loss_dict_ema[key] for key in loss_dict_ema}
-        self.log_dict(loss_dict_no_ema, prog_bar=False, logger=True, on_step=False, on_epoch=True)
-        self.log_dict(loss_dict_ema, prog_bar=False, logger=True, on_step=False, on_epoch=True)
+        self.log_dict(loss_dict_no_ema, prog_bar=False, logger=True, on_step=False, on_epoch=True, sync_dist=True)
+        self.log_dict(loss_dict_ema, prog_bar=False, logger=True, on_step=False, on_epoch=True, sync_dist=True)
 
     def on_train_batch_end(self, *args, **kwargs):
         if self.use_ema:
@@ -505,7 +505,7 @@ class LatentDiffusion(DDPM):
 
     @rank_zero_only
     @torch.no_grad()
-    def on_train_batch_start(self, batch, batch_idx, dataloader_idx):
+    def on_train_batch_start(self, batch, batch_idx):
         # only for very first batch
         if self.scale_by_std and self.current_epoch == 0 and self.global_step == 0 and batch_idx == 0 and not self.restarted_from_ckpt:
             assert self.scale_factor == 1., 'rather not use custom rescaling and std-rescaling simultaneously'

--- a/ldm/modules/embedding_manager.py
+++ b/ldm/modules/embedding_manager.py
@@ -1,5 +1,5 @@
 import torch
-from torch import nn
+from torch import Tensor, nn
 
 from ldm.data.personalized import per_img_token_list
 from transformers import CLIPTokenizer
@@ -148,8 +148,7 @@ class EmbeddingManager(nn.Module):
         return self.string_to_param_dict.parameters()
 
     def embedding_to_coarse_loss(self):
-        
-        loss = 0.
+        loss = torch.tensor(0.)
         num_embeddings = len(self.initial_embeddings)
 
         for key in self.initial_embeddings:


### PR DESCRIPTION
#### What this does:
This PR works to resolve all deprecation warnings and hard incompatibilities with current versions of PyTorch-Lightning.  It also sets `1.7.7` as the requested version in `environment.yaml`.

Switches from the now completely dead and gone `TestTubeLogger` to the now Lightning default `TensorBoardLogger`.  If you need to use another logger, you should be able to set it up in the configs.  It seems to work more or less the same as `TestTubeLogger`, in-so-far as how Textual Inversion was using it.

There are a few other minor code adjustments:
- Shifting things to better locations in Lightning modules.
  - Like how the keyboard interrupt checkpointing is handled.
  - Or how the loaded dataset info is reported to console.
- Resolving some warnings displayed by the IDE I found in, probably, unused code-paths.
- Adding a `.gitignore` to exclude a few things that have appeared while using TI and probably shouldn't be committed.

#### What this does not do:
The reason for all these deprecation warnings was they were shifting towards a hardware agnostic API.  In order to become hardware agnostic, we'd need to apply [a few additional changes](https://pytorch-lightning.readthedocs.io/en/stable/accelerators/accelerator_prepare.html) here and there.  I'm leaving that to someone else to resolve, if it interests them.

I don't know if this will run on other accelerators besides GPU and maybe CPU in its current state, but someone else can make those changes if it interests them.

#### Why?
My AMD system is a house of cards when it comes to compute, and it was having difficulty inter-operating with Anaconda.  Having to run on the global installation of Python and it's abysmal package management, I needed to bring Textual Inversion up to date so it was not fighting with other Stable Diffusion libraries that were keeping up with their dependencies.

There's been some big updates to the ROCm stack lately, so maybe I can now use Anaconda!?  ...but that was after I had already started this journey.  Doing dependency upkeep (especially on your core framework) is a good thing anyways, so here's the PR!

Additionally, after updating and using the new strategies and accelerators system, I got a **60%** performance boost, because the hard-coded DDP mode was detrimental to my single-GPU setup.  PyTorch-Lightning has actually gotten quite good at auto-detecting the best execution method for compute code, so I left it un-opinionated and updated the readme to demonstrate the `--accellerator gpu` flag, which probably isn't even needed...  But since I have not tested the other accelerators besides GPU, it's the one to put there in the demo.

If you really want to force the DDP strategy, you can use `--strategy ddp` to set it up.

#### What needs special review attention:
I am not setup for anything besides Stable Diffusion and I'm frankly afraid to jostle this fragile setup trying to test training for other models.  I would appreciate it if someone who is setup to test the `autoencoder` and `latent-diffusion` configs could please give this branch a try and make sure no deprecation warnings appear for an epoch or two of training.