### PR TITLE
Add `out_dir` to evaluate_model.py

### DIFF
--- a/scripts/evaluate_model.py
+++ b/scripts/evaluate_model.py
@@ -62,6 +62,12 @@ if __name__ == "__main__":
         help="Path to directory with images used to train the embedding vectors"
     )
 
+    parser.add_argument(
+        "--out_dir",
+        type=str,
+        help="Path to output directory"
+    )
+    
     opt = parser.parse_args()
 
 


### PR DESCRIPTION
Fixes `AttributeError: 'Namespace' object has no attribute 'out_dir'`