### PR TITLE
New Feature: Vector Shuffling

### DIFF
--- a/ldm/modules/embedding_manager.py
+++ b/ldm/modules/embedding_manager.py
@@ -1,6 +1,8 @@
 import torch
 from torch import nn
 
+from ldm.util import default
+from ldm.modules.embedding_shuffler import get_shuffler
 from ldm.data.personalized import per_img_token_list
 from transformers import CLIPTokenizer
 from functools import partial
@@ -35,6 +37,7 @@ class EmbeddingManager(nn.Module):
             embedder,
             placeholder_strings=None,
             initializer_words=None,
+            shuffle_mode=None,
             per_image_tokens=False,
             num_vectors_per_token=1,
             progressive_words=False,
@@ -48,6 +51,7 @@ class EmbeddingManager(nn.Module):
 
         self.initial_embeddings = nn.ParameterDict() # These should not be optimized
 
+        self.shuffle_embeddings = get_shuffler(default(shuffle_mode, "off"))
         self.progressive_words = progressive_words
         self.progressive_counter = 0
 
@@ -107,6 +111,7 @@ class EmbeddingManager(nn.Module):
                     max_step_tokens = self.max_vectors_per_token
 
                 num_vectors_for_token = min(placeholder_embedding.shape[0], max_step_tokens)
+                shuffle_view = self.shuffle_embeddings(placeholder_embedding, num_vectors_for_token)
 
                 placeholder_rows, placeholder_cols = torch.where(tokenized_text == placeholder_token.to(device))
 
@@ -121,7 +126,7 @@ class EmbeddingManager(nn.Module):
                     col = sorted_cols[idx]
 
                     new_token_row = torch.cat([tokenized_text[row][:col], placeholder_token.repeat(num_vectors_for_token).to(device), tokenized_text[row][col + 1:]], axis=0)[:n]
-                    new_embed_row = torch.cat([embedded_text[row][:col], placeholder_embedding[:num_vectors_for_token], embedded_text[row][col + 1:]], axis=0)[:n]
+                    new_embed_row = torch.cat([embedded_text[row][:col], shuffle_view, embedded_text[row][col + 1:]], axis=0)[:n]
 
                     embedded_text[row]  = new_embed_row
                     tokenized_text[row] = new_token_row

--- a/ldm/modules/embedding_shuffler.py
+++ b/ldm/modules/embedding_shuffler.py
@@ -1,0 +1,129 @@
+from typing import Union, Callable, Optional, Literal
+
+import torch
+from torch import Tensor
+
+from ldm.util import default
+
+ShuffleMode = Union[
+    Literal["off"],
+    Literal["on", "all"],
+    Literal["trailing", "leading", "between"],
+    Literal["progressive", "dynamic"]
+]
+ShuffleFn = Union[
+    Callable[[Tensor], Tensor],
+    Callable[[Tensor, Optional[int]], Tensor]
+]
+
+def idx_of(value: int, device: torch.device):
+    """Helper that makes single-value tensors for some device."""
+    return torch.tensor([value], dtype=torch.int64, device=device)
+
+def shuffle_off(placeholder_embedding: Tensor, num_vectors: Optional[int]=None):
+    """Performs no shuffling, but will still trim to the number of vectors."""
+    num_vectors = default(num_vectors, placeholder_embedding.shape[0])
+    return placeholder_embedding[:num_vectors]
+
+def shuffle_all(placeholder_embedding: Tensor, num_vectors: Optional[int]=None):
+    """Shuffles all embeddings."""
+    num_vectors = default(num_vectors, placeholder_embedding.shape[0])
+    d = placeholder_embedding.device
+    if num_vectors >= 2:
+        trim_source = placeholder_embedding[:num_vectors]
+        shuffle_idx = torch.randperm(num_vectors, device=d)
+        return trim_source[shuffle_idx].view(trim_source.size())
+    
+    # No effect with fewer than 2 vectors.
+    return shuffle_off(placeholder_embedding, num_vectors)
+
+def shuffle_trailing(placeholder_embedding: Tensor, num_vectors: Optional[int]=None):
+    """Shuffles everything after first embedding."""
+    num_vectors = default(num_vectors, placeholder_embedding.shape[0])
+    d = placeholder_embedding.device
+    if num_vectors >= 3:
+        trim_source = placeholder_embedding[:num_vectors]
+        shuffle_idx = torch.randperm(num_vectors - 1, device=d) + 1
+        shuffle_idx = torch.cat([idx_of(0, d), shuffle_idx])
+        return trim_source[shuffle_idx].view(trim_source.size())
+
+    # No effect with fewer than 3 vectors.
+    return shuffle_off(placeholder_embedding, num_vectors)
+
+def shuffle_leading(placeholder_embedding: Tensor, num_vectors: Optional[int]=None):
+    """Shuffles everything before the last embedding."""
+    num_vectors = default(num_vectors, placeholder_embedding.shape[0])
+    d = placeholder_embedding.device
+    if num_vectors >= 3:
+        trim_source = placeholder_embedding[:num_vectors]
+        shuffle_idx = torch.randperm(num_vectors - 1, device=d)
+        shuffle_idx = torch.cat([shuffle_idx, idx_of(num_vectors - 1, d)])
+        return trim_source[shuffle_idx].view(trim_source.size())
+
+    # No effect with fewer than 3 vectors.
+    return shuffle_off(placeholder_embedding, num_vectors)
+
+def shuffle_between(placeholder_embedding: Tensor, num_vectors: Optional[int]=None):
+    """Shuffles between the first and last embeddings."""
+    num_vectors = default(num_vectors, placeholder_embedding.shape[0])
+    d = placeholder_embedding.device
+    if num_vectors >= 4:
+        trim_source = placeholder_embedding[:num_vectors]
+        shuffle_idx = torch.randperm(num_vectors - 2, device=d) + 1
+        shuffle_idx = torch.cat([idx_of(0, d), shuffle_idx, idx_of(num_vectors - 1, d)])
+        return trim_source[shuffle_idx].view(trim_source.size())
+
+    # No effect with fewer than 4 vectors.
+    return shuffle_off(placeholder_embedding, num_vectors)
+
+def shuffle_progressive(placeholder_embedding: Tensor, num_vectors: Optional[int]=None):
+    """
+    Always includes the first and last embeddings (if `num_vectors` is large enough)
+    while shuffling the embeddings in between.  Unlike `shuffle_dynamic`, this
+    establishes stable intro and outro embeddings ASAP.
+
+    This was made as an option for progressive words mode.
+    """
+    num_vectors = default(num_vectors, placeholder_embedding.shape[0])
+    d = placeholder_embedding.device
+    if num_vectors == 2:
+        # Only `[<first>, <last>]`.
+        last_idx = placeholder_embedding.shape[0] - 1
+        shuffle_idx = torch.cat([idx_of(0, d), idx_of(last_idx, d)])
+        return placeholder_embedding[shuffle_idx].view(num_vectors, -1)
+    if num_vectors > 2:
+        # Now `[<first>, ...<random[1:num_vectors-1]>, <last>]`
+        last_idx = placeholder_embedding.shape[0] - 1
+        shuffle_idx = torch.randperm(num_vectors-2, device=d) + 1
+        shuffle_idx = torch.cat([idx_of(0, d), shuffle_idx, idx_of(last_idx, d)])
+        return placeholder_embedding[shuffle_idx].view(num_vectors, -1)
+
+    # No effect with fewer than 2 vectors.
+    return shuffle_off(placeholder_embedding, num_vectors)
+
+def shuffle_dynamic(placeholder_embedding: Tensor, num_vectors: Optional[int]=None):
+    """
+    Tries to always perform an embedding shuffle when possible.
+    
+    The type of shuffle done depends on the number of vectors:
+    * 4 or more uses `between` shuffling.
+    * 3 uses `trailing` shuffling.
+    * 2 or less uses `all` shuffling.
+    """
+    num_vectors = default(num_vectors, placeholder_embedding.shape[0])
+    if num_vectors >= 4: return shuffle_between(placeholder_embedding, num_vectors)
+    if num_vectors == 3: return shuffle_trailing(placeholder_embedding, num_vectors)
+    return shuffle_all(placeholder_embedding, num_vectors)
+
+def get_shuffler(shuffle_mode: Union[bool, ShuffleMode]) -> ShuffleFn:
+    if shuffle_mode == True: shuffle_mode = "all"
+    elif shuffle_mode == "on": shuffle_mode = "all"
+    elif shuffle_mode == False: shuffle_mode = "off"
+
+    if shuffle_mode == "all": return shuffle_all
+    if shuffle_mode == "dynamic": return shuffle_dynamic
+    if shuffle_mode == "progressive": return shuffle_progressive
+    if shuffle_mode == "between": return shuffle_between
+    if shuffle_mode == "trailing": return shuffle_trailing
+    if shuffle_mode == "leading": return shuffle_leading
+    return shuffle_off


### PR DESCRIPTION
*This is a back-port of a feature I created in my own fork which now has heavy refactors, but it was working so well, I felt I had to clean it up and offer it back to the main repo.*

I've been working a lot with multi-vector embeddings lately.

One issue I've been having is what I had termed as "vector cross-talk".  This is where you might be training an embedding on a character with blue eyes and red hair, but the AI sometimes generates imagery of the character with red eyes and blue hair, or blue eyes and blue hair, etc.

I suspected that the cross-talk is because vectors are encoding individual colors represented by the character and the AI sometimes just free associates them to other features of the embedding and/or prompt.  So, what if the AI could not rely on vector ordering as much when learning?

This introduces a feature called vector shuffling, where the embeddings of individual vectors are shuffled randomly when they're inserted into the prompt during training.  The idea is that it will force it to encode sharper and more focused concepts into each vector.  No more `blue AND eyes AND red AND hair`.  Because it's scrambled, it can only learn the concept correctly if it encodes the entirety of the concept in one embedding, IE `blue eyes AND red hair`.

This is probably why using only 1 vector got the best results in the study; it had no choice but to encode a focused embedding when it had only 1 vector.  This feature tries to bridge the gap and give the best of both worlds: more storage for more complex subjects and focused vectors that resist leaking into other aspects of the prompt.

That's the theory, anyways.  I'm no data scientist, so someone who is can take this and test these claims, but doing this seemed to cut down on vector cross-talk in my tests.  It can still happen, but it significantly reduced occurrences and their severity when using the trained embedding.

You can enable this feature by setting `model.params.personalization_config.params.shuffle_mode` to `true` in your project's config YAML file, and it will shuffle all vectors.

Having done a lot of experimentation with the concept, it also supports the following additional options.  Experiment with them and see what works best for your particular subject.
- `all` or `on` or `true` - Shuffles all vectors.
- `off` or `false` - Disables shuffling; the default if it is not specified in your config.
- `trailing` - With 3 or more vectors, shuffle all vectors after the first.  This provides a stable "intro" vector.
- `leading` - With 3 or more vectors, shuffle all vectors before the last.  This provides a stable "outro" vector.
- `between` - With 4 or more vectors, shuffles all vectors between the first and last.
  - This creates stable "intro" and "outro" vectors, allowing the embedding to take some advantage of token ordering during training.  That is, if you use your embedding like a name, this preserves a chance of learning that intended usage and taking advantage of that.  The idea is it will learn to use the first and last vectors as cues leading in and out of the embedding cleanly and minimize disruption to other parts of the prompt.
- `progressive` - A special mode for `progressive_words`.  Like `between`, it also establishes stable "intro" and "outro" vectors, but ensures that the first and last vectors are kept the same throughout training as more vectors are added.
  - Needs `num_vectors_per_token` to be at least 3 to have any notable effect.
  - Vectors between the first and last are still shuffled as in `between`, when there's enough vectors unlocked to do so.
  - You will want to make sure that all vectors get some training (`num_vectors_per_token * 2000` steps of training need to have occurred), otherwise some of the middle vectors may still be the initialization word's embedding.
- `dynamic` - The "just make it work no matter what" option that favors stability.  This tries to always shuffle the vectors but also tries to establish stable intro and outro vectors when the number of vectors permits it.  What shuffle mode it ultimately uses differs based on how many vectors there are.
  - With 1 vector, uses `off`.
  - With 2 vectors, uses `all`.
  - With 3 vectors, uses `trailing` to at least establish a stable intro vector.
  - With 4 or more vectors, uses `between` to establish both intro and outro vectors.

If the number of vectors is below the supported number for an option, it acts the same as `off` unless otherwise noted.

The `dynamic` setting exists because some of my experiments allowed for different numbers of vectors for different placeholders when training multi-placeholder embeddings (like in the `per_image_tokens` mode).  It's also just a good option to suggest when someone isn't sure which to use.  It will try to provide as much benefit as it can regardless of what `num_vectors_per_token` is set to.